### PR TITLE
Add a random number generator to sensor pt 1

### DIFF
--- a/app/src/main/java/com/plangrid/plansensor/MainActivity.java
+++ b/app/src/main/java/com/plangrid/plansensor/MainActivity.java
@@ -21,7 +21,9 @@ public class MainActivity extends AppCompatActivity {
 
         ButterKnife.bind(this);
 
-        // display data in the graph by passing it a list of data points
+        // Display data in the graph by passing it a list of data points.
         graph.setData(Arrays.asList(1, 5, 6, 4, 2, 1, 1, 3, 8));
+
+        // TODO(1): Listen to the sensor and display the last ten values in the graph.
     }
 }

--- a/app/src/main/java/com/plangrid/plansensor/Sensor.java
+++ b/app/src/main/java/com/plangrid/plansensor/Sensor.java
@@ -1,0 +1,29 @@
+package com.plangrid.plansensor;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.Observable;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+
+public class Sensor {
+
+    private Random random = new Random();
+
+    public Observable<Integer> getSensorObservable() {
+        // TODO(2): Replace with hitting an endpoint for a value every second.
+//        return serverRetrievedSensorValues();
+
+        return locallyGeneratedRandomNumbers();
+    }
+
+    private Observable<Integer> locallyGeneratedRandomNumbers() {
+        return Observable.interval(1, TimeUnit.SECONDS)
+                .map(it -> random.nextInt())
+                .observeOn(AndroidSchedulers.mainThread());
+    }
+
+    private Observable<Integer> serverRetrievedSensorValues() {
+        throw new UnsupportedOperationException("Please implement.");
+    }
+}


### PR DESCRIPTION
## Summary:
Some candidates struggle with making API calls. It's difficult to tell whether this is a stack familiarity issue or not, so let's move that portion to the end. Since I think we get more valuable signal from the portion afterwards (i.e. decisions in how to show the data in the UI, how to limit to ten values, how rotations are handled), this helps us get that signal earlier.

Note: I'm a little concerned that implementing the randomNumGenerator in RX is too encouraging of using RX. Considering the number of candidates I've seen try RX now anyway even with encouragement not to, I think this is fine. I also think that Observable.interval is a little obscure so showing users how to run something every second is helpful too. I'm a little worried it's *too* helpful, but if it is, we can always focus more on persistence of the data (which will definitely fill up the hour).

## Test Plan:
created a sensor, created a list, filled the list with the random sensor values, subscribed graph to it, everything works dandy